### PR TITLE
Fix code scanning alert no. 7: Flask app is run in debug mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -707,4 +707,5 @@ def download_resume():
 if __name__ == '__main__':
     with app.app_context():
         db.create_all()
-    app.run(debug=True)
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(debug=debug_mode)


### PR DESCRIPTION
Fixes [https://github.com/se2024-jpg/WolfTrack6.0/security/code-scanning/7](https://github.com/se2024-jpg/WolfTrack6.0/security/code-scanning/7)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is to control the debug mode based on an environment variable. This way, we can enable debug mode during development and disable it in production without changing the code.

1. Import the `os` module if not already imported.
2. Modify the `app.run()` call to set the `debug` parameter based on an environment variable, such as `FLASK_DEBUG`.
3. Set the default value of the `FLASK_DEBUG` environment variable to `False` to ensure that debug mode is disabled by default.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
