### PR TITLE
Fix code scanning alert no. 11: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -645,7 +645,8 @@ def save_resume():
             return jsonify({"message": "Resume updated successfully!"}), 200
         except Exception as e:
             db.session.rollback()
-            return jsonify({"message": f"Error updating resume: {str(e)}"}), 500
+            app.logger.error(f"Error updating resume: {str(e)}")
+            return jsonify({"message": "An internal error has occurred."}), 500
     else:
         try:
             resume = Resume(**data)
@@ -654,7 +655,8 @@ def save_resume():
             return jsonify({"message": "Resume saved successfully!"}), 200
         except Exception as e:
             db.session.rollback()
-            return jsonify({"message": f"Error saving resume: {str(e)}"}), 500
+            app.logger.error(f"Error saving resume: {str(e)}")
+            return jsonify({"message": "An internal error has occurred."}), 500
 
 @app.route('/delete_resume', methods=['DELETE'])
 def delete_resume():
@@ -667,7 +669,8 @@ def delete_resume():
             return jsonify({"message": "Resume deleted successfully!"}), 200
         except Exception as e:
             db.session.rollback()
-            return jsonify({"message": f"Error deleting resume: {str(e)}"}), 500
+            app.logger.error(f"Error deleting resume: {str(e)}")
+            return jsonify({"message": "An internal error has occurred."}), 500
     else:
         return jsonify({"message": "Resume not found"}), 404
 


### PR DESCRIPTION
Fixes [https://github.com/se2024-jpg/WolfTrack6.0/security/code-scanning/11](https://github.com/se2024-jpg/WolfTrack6.0/security/code-scanning/11)

To fix the problem, we need to ensure that detailed error messages and stack traces are not exposed to end users. Instead, we should log the detailed error information on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the error and return a generic message.

1. Import the `logging` module to enable logging of error messages.
2. Replace the detailed error messages returned to the user with a generic message.
3. Log the detailed error messages on the server for debugging purposes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
