### PR TITLE
Fix code scanning alert no. 9: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 import os
+import logging
 from flask import Flask, jsonify, request, render_template, make_response, redirect, url_for, send_from_directory, session, flash, send_file
 from flask_sqlalchemy import SQLAlchemy
 from flask_bcrypt import Bcrypt
@@ -25,6 +26,7 @@ from reportlab.lib.pagesizes import letter
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.lib.units import inch
 from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, Table, TableStyle
+logging.basicConfig(level=logging.ERROR)
 
 app = Flask(__name__)
 bcrypt = Bcrypt(app)
@@ -645,7 +647,8 @@ def save_resume():
             return jsonify({"message": "Resume updated successfully!"}), 200
         except Exception as e:
             db.session.rollback()
-            return jsonify({"message": f"Error updating resume: {str(e)}"}), 500
+            logging.error(f"Error updating resume: {str(e)}")
+            return jsonify({"message": "An internal error has occurred."}), 500
     else:
         try:
             resume = Resume(**data)
@@ -654,7 +657,8 @@ def save_resume():
             return jsonify({"message": "Resume saved successfully!"}), 200
         except Exception as e:
             db.session.rollback()
-            return jsonify({"message": f"Error saving resume: {str(e)}"}), 500
+            logging.error(f"Error saving resume: {str(e)}")
+            return jsonify({"message": "An internal error has occurred."}), 500
 
 @app.route('/delete_resume', methods=['DELETE'])
 def delete_resume():
@@ -667,7 +671,8 @@ def delete_resume():
             return jsonify({"message": "Resume deleted successfully!"}), 200
         except Exception as e:
             db.session.rollback()
-            return jsonify({"message": f"Error deleting resume: {str(e)}"}), 500
+            logging.error(f"Error deleting resume: {str(e)}")
+            return jsonify({"message": "An internal error has occurred."}), 500
     else:
         return jsonify({"message": "Resume not found"}), 404
 


### PR DESCRIPTION
Fixes [https://github.com/se2024-jpg/WolfTrack6.0/security/code-scanning/9](https://github.com/se2024-jpg/WolfTrack6.0/security/code-scanning/9)

To fix the problem, we need to ensure that detailed exception information is not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by using a logging mechanism to record the exception details and modifying the response to return a generic error message.

**Steps to fix:**
1. Import the `logging` module to enable logging of exceptions.
2. Configure the logging settings if not already configured.
3. Replace the detailed error message in the JSON response with a generic message.
4. Log the detailed exception message on the server.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
